### PR TITLE
Add require 'rubygems' before requiring json gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,7 @@
 
 require 'open-uri'
 require 'openssl'
+require 'rubygems'
 require 'json'
 
 


### PR DESCRIPTION
Without this ruby can't find json in some less forgiving versions of ruby
