### PR TITLE
Extract vundle specific mappings into separate file

### DIFF
--- a/vundle.vim
+++ b/vundle.vim
@@ -20,13 +20,3 @@ endfor
 unlet g:vundle_installing_plugins
 
 call vundle#end()
-
-command! ReloadVundle source ~/.vim/vundle.vim
-function PluginReloadAndRun(command)
-  :ReloadVundle
-  execute a:command
-endfunction
-
-nnoremap <Leader>pi :call PluginReloadAndRun("PluginInstall")<CR>
-nnoremap <Leader>pu :call PluginReloadAndRun("PluginInstall!")<CR>
-nnoremap <Leader>pc :call PluginReloadAndRun("PluginClean")<CR>

--- a/vundle_plugins/vundle.vim
+++ b/vundle_plugins/vundle.vim
@@ -1,0 +1,13 @@
+if exists('g:vundle_installing_plugins')
+  finish
+endif
+
+command! ReloadVundle source ~/.vim/vundle.vim
+function PluginReloadAndRun(command)
+  :ReloadVundle
+  execute a:command
+endfunction
+
+nnoremap <Leader>pi :call PluginReloadAndRun("PluginInstall")<CR>
+nnoremap <Leader>pu :call PluginReloadAndRun("PluginInstall!")<CR>
+nnoremap <Leader>pc :call PluginReloadAndRun("PluginClean")<CR>


### PR DESCRIPTION
Issue: Mappings.vim, which is sourced later, declares mapleader and thus renders these mapping unusable.
Solution: Move these vundle specific settings into their own file. Follow existing convention.

Please pull.
