### PR TITLE
Update vim-json to the recommended version

### DIFF
--- a/vundle_plugins/vim-json.vim
+++ b/vundle_plugins/vim-json.vim
@@ -1,4 +1,4 @@
 if exists('g:vundle_installing_plugins')
-  Plugin 'leshill/vim-json'
+  Plugin 'elzr/vim-json'
   finish
 endif


### PR DESCRIPTION
The original vim-json has been [superseded](http://www.vim.org/scripts/script.php?script_id=1945) by [elzr's much-improved version](https://github.com/elzr/vim-json).  Pardon if you've already examined that version and decided against it, but if you haven't it's a must-see.
