### PR TITLE
Change empty space marker to •

### DIFF
--- a/config.vim
+++ b/config.vim
@@ -109,7 +109,7 @@ set listchars=""
 " make tabs visible
 set listchars=tab:▸▸
 " show trailing spaces as dots
-set listchars+=trail:.
+set listchars+=trail:•
 " The character to show in the last column when wrap is off and the line
 " continues beyond the right of the screen
 set listchars+=extends:>


### PR DESCRIPTION
Just a small change to a nicer empty space graphical character (and for me an exercise in how to use `git checkout -p 3cf165a37a44cd20c62c2a820496d3dd9b` that let you interactively approve/reject blobs from another commit. Very interesting!
