### PR TITLE
add Tim Pope's vim-endwise

### DIFF
--- a/vundle_plugins/vim-endwise.vim
+++ b/vundle_plugins/vim-endwise.vim
@@ -1,0 +1,4 @@
+if exists('g:vundle_installing_plugins')
+  Plugin 'tpope/vim-endwise'
+  finish
+endif


### PR DESCRIPTION
This is just a suggestion in the form of a pull request.  Won't be offended if you skip it.

I wanted ruby to automatically populate "ends" for me on blocks so I don't have to do `end Esc O` all the time.

vim-endwise handles that for ruby as well as a number of other languages.

Not life-changing, but I like it and thought you might.  If the vcoc handles this already in some other fashion, I'd be glad to know since it doesn't seem automatic.
