### PR TITLE
use git:// instead of http:// for centos

### DIFF
--- a/scripts/setup
+++ b/scripts/setup
@@ -23,7 +23,7 @@ echo ''
 
 info 'Installing Vundle'
 info '-----------------'
-git clone http://github.com/gmarik/vundle.git bundle/vundle
+git clone git://github.com/gmarik/vundle.git bundle/vundle
 
 info 'Setting up Symlinks'
 info '--------------'


### PR DESCRIPTION
I'm experimenting with CentOS 6.5 in my work environment, and for some reason git hangs on the http:// protocol in the setup script.

Since I've always seen these kinds of urls specified as git:// instead of http:// anyway, I figured I'd give that a try and it worked a treat.  I feel confident it wouldn't cause problems in any other environment, so I'm submitting a pull request.

Thanks.
