### PR TITLE
Make the project directory may be located in not only ~/.vim.

### DIFF
--- a/config.vim
+++ b/config.vim
@@ -15,13 +15,13 @@ endif
 " -----------------------------
 " File Locations
 " -----------------------------
-set backupdir=~/.vim/.backup// " Double // causes backups to use full file path
-set directory=~/.vim/.tmp//
-set spellfile=~/.vim/spell/custom.en.utf-8.add
+let &backupdir=expand('<sfile>:p:h') . '/.backup/'
+let &directory=expand('<sfile>:p:h') . '/.tmp/'
+let &spellfile=expand('<sfile>:p:h') . '/spell/custom.en.utf-8.add'
 " Persistent Undo
 if has('persistent_undo')
   set undofile
-  set undodir=~/.vim/.undo
+  let &undodir=expand('<sfile>:p:h') . '/.undo'
 endif
 
 " ---------------

--- a/plugins.vim
+++ b/plugins.vim
@@ -1,4 +1,4 @@
 " Source all the plugin files again, this time loading their configuration.
-for file in split(glob('~/.vim/vundle_plugins/*.vim'), '\n')
+for file in split(glob(expand('<sfile>:p:h') . '/vundle_plugins/*.vim'), '\n')
   exe 'source' file
 endfor

--- a/scripts/setup
+++ b/scripts/setup
@@ -23,26 +23,26 @@ echo ''
 
 info 'Installing Vundle'
 info '-----------------'
-git clone git://github.com/gmarik/vundle.git bundle/vundle
+git clone https://github.com/VundleVim/Vundle.vim.git bundle/vundle
 
-info 'Setting up Symlinks'
-info '--------------'
-if test $(which rake)
-then
-  rake vim:link
-else
-  fail 'Install Ruby and Rake to continue'
-fi
+# info 'Setting up Symlinks'
+# info '--------------'
+# if test $(which rake)
+# then
+#   rake vim:link
+# else
+#   fail 'Install Ruby and Rake to continue'
+# fi
 
 info 'Installing plugins'
 info '-------------------------------------------------'
 if test $(which mvim)
 then
-  mvim -v +PluginInstall +qall
+  mvim -u $(dirname $(dirname $0))/vimrc -v +PluginInstall +qall
 else
   if test $(which vim)
   then
-    vim +PluginInstall +qall
+    vim -u $(dirname $(dirname $0))/vimrc  +PluginInstall +qall
   else
     fail 'mvim or vim not found in path.'
   fi

--- a/vimrc
+++ b/vimrc
@@ -5,22 +5,22 @@
 " =============================================================================
 
 " All of the plugins are installed with Vundle from this file.
-source ~/.vim/vundle.vim
+source <sfile>:p:h/vundle.vim
 
 " Automatically detect file types. (must turn on after Vundle)
 filetype plugin indent on
 
 " Platform (Windows, Mac, etc.) configuration.
-source ~/.vim/platforms.vim
+source <sfile>:p:h/platforms.vim
 " All of the Vim configuration.
-source ~/.vim/config.vim
+source <sfile>:p:h/config.vim
 " New commands
-source ~/.vim/commands.vim
+source <sfile>:p:h/commands.vim
 " All hotkeys, not dependant on plugins, are mapped here.
-source ~/.vim/mappings.vim
+source <sfile>:p:h/mappings.vim
 " Load plugin-specific configuration.
-source ~/.vim/plugins.vim
+source <sfile>:p:h/plugins.vim
 " Small custom functions.
-source ~/.vim/functions.vim
+source <sfile>:p:h/functions.vim
 " Auto commands.
-source ~/.vim/autocmds.vim
+source <sfile>:p:h/autocmds.vim

--- a/vundle.vim
+++ b/vundle.vim
@@ -5,8 +5,9 @@
 set nocompatible " be iMproved
 filetype off     " required!
 
-set runtimepath+=~/.vim/bundle/vundle/
-call vundle#begin()
+exe 'set runtimepath+=' . expand('<sfile>:p:h') . '/bundle/vundle'
+" Here use '{__folder_scriptfile_located_in__}/bundle' as the bundles directory.
+call vundle#begin(expand('<sfile>:p:h') . '/bundle')
 
 " let Vundle manage Vundle, required
 Plugin 'gmarik/vundle'
@@ -14,10 +15,10 @@ Plugin 'gmarik/vundle'
 " Source all the plugins with a global variable set that ensures only the
 " Plugin 'name' code will be called.
 let g:vundle_installing_plugins = 1
-for file in split(glob('$HOME/.vim/vundle_plugins/*.vim'), '\n')
+for file in split(glob(expand('<sfile>:p:h') . '/vundle_plugins/*.vim'), '\n')
   exe 'source' fnameescape(file)
 endfor
-for file in split(glob('$HOME/.vim/vundle_plugins/custom/*.vim'), '\n')
+for file in split(glob(expand('<sfile>:p:h') . '/vundle_plugins/custom/*.vim'), '\n')
   exe 'source' fnameescape(file)
 endfor
 unlet g:vundle_installing_plugins

--- a/vundle_plugins/vundle.vim
+++ b/vundle_plugins/vundle.vim
@@ -2,7 +2,7 @@ if exists('g:vundle_installing_plugins')
   finish
 endif
 
-command! ReloadVundle source ~/.vim/vundle.vim
+execute 'command! ReloadVundle source' expand('<sfile>:p:h:h') . '/vundle.vim'
 function PluginReloadAndRun(command)
   :ReloadVundle
   execute a:command


### PR DESCRIPTION
Dear Jeremy Mack,

* I change some code to make the project directory may be located in not only `~/.vim`, thus we can keep more than one vim configuration projects in same time.
* Discovering your dot_vim, as remembered, two years ago, I choose it. It is an awesome vim configuration. However, I also have some configurations of vim for special targets, which demands switching between multiple configs. 
* Please accept it to make people easier to test & choose you project without breaking their original one. Thank you very much! ^_^ 