### PR TITLE
Corrected Neovim support and Vundle .vim

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ PLUGINS_HEADER = <<-HEADER.chomp
 | -------: | :--------- | :-------------- |
 HEADER
 
-FILES_TO_LINK = %w{vimrc gvimrc nvimrc}
+FILES_TO_LINK = %w{vimrc gvimrc}
 
 task :default => ['vim:link']
 
@@ -34,6 +34,14 @@ namespace :vim do
           File.symlink(".vim/#{file}", dot_file)
           puts "Created link for #{file} in your home folder."
         end
+      end
+      neovim_config_file = File.expand_path("~/.vim/nvimrc");
+      neovim_dot_file = File.expand_path("~/.config/nvim/init.vim")
+      if File.exists? neovim_dot_file
+          puts "#{neovim_dot_file} already exists, skipping link."
+        else
+          File.symlink(neovim_config_file, neovim_dot_file)
+          puts "Created link for nvimrc in your home folder."
       end
     rescue NotImplementedError
       puts "File.symlink not supported, you must do it manually."

--- a/vundle.vim
+++ b/vundle.vim
@@ -5,11 +5,11 @@
 set nocompatible " be iMproved
 filetype off     " required!
 
-set runtimepath+=~/.vim/bundle/vundle/
+set runtimepath+=~/.vim/bundle/Vundle.vim
 call vundle#begin()
 
 " let Vundle manage Vundle, required
-Plugin 'gmarik/vundle'
+Plugin 'VundleVim/Vundle.vim'
 
 " Source all the plugins with a global variable set that ensures only the
 " Plugin 'name' code will be called.


### PR DESCRIPTION
Neovim now uses ~/.config/nvim/init.vim for its initialization, so symlink in RakeFile is updated.

Vundle.vim was having wrong rtp for Vundle setup by setup script, resulting in failing of PluginInstall command. The problem is now fixed. (Solve Issue #26).