### PR TITLE
Add Editorconfig to dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ dependencies.
   installed.
 * [Source Code Nerd Font Complete](https://git.io/vPBU6) The custom font I'm using
   for vim-airline and vim-devicons.
+* [Editorconfig.vim](https://github.com/editorconfig/editorconfig-vim) Requires [editorconfig](http://editorconfig.org/) to be installed.
 
 ## Mappings
 


### PR DESCRIPTION
I was getting an error for EditorConfig when I installed your configuration from scratch.
`EditorConfig: Failed to initialize external_command mode`

I found out from EditorConfig.vim that I had to install via `brew install editorconfig`.