### PR TITLE
fix: load configuration of custom plugins

### DIFF
--- a/plugin_config.vim
+++ b/plugin_config.vim
@@ -2,3 +2,7 @@
 for file in split(glob(g:vimdir . '/plug_plugins/*.vim'), '\n')
   exe 'source' file
 endfor
+
+for file in split(glob(g:vimdir . '/plug_plugins/custom/*.vim'), '\n')
+  exe 'source' file
+endfor


### PR DESCRIPTION
Custom plugins in directory `plug_plugins` are loaded, but their configuration isn't. This patch should fix it.