### PR TITLE
Remap "Scroll Larger Amounts" to <C-j> / <C-k> to match documentation…

### DIFF
--- a/mappings.vim
+++ b/mappings.vim
@@ -90,10 +90,10 @@ nnoremap <silent> gx :wincmd x<CR>
 inoremap <C-l> <C-x><C-l>
 
 " Scroll larger amounts with C-j / C-k
-nnoremap gj 15gjzz
-nnoremap gk 15gkzz
-vnoremap gj 15gjzz
-vnoremap gk 15gkzz
+nnoremap <C-j> 15gjzz
+nnoremap <C-k> 15gkzz
+vnoremap <C-j> 15gjzz
+vnoremap <C-k> 15gkzz
 
 " ---------------
 " Insert Mode Mappings


### PR DESCRIPTION
… and avoid avoid conflict with "Window Movement"

The mapping for "Scroll Larger Amounts" conflicted with with the mapping for window moment.
I remapped to <C-j> & <C-k> as the comment suggested