### PR TITLE
* Use github access token.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -181,8 +181,8 @@ def repo_info(user, name)
   # Without a GitHub Client / Secret token you will only be able to make 60
   # requests per hour, meaning you can only update the readme once.
   # Read more here http://developer.github.com/v3/#rate-limiting.
-  if ENV['GITHUB_CLIENT_ID'] and ENV['GITHUB_CLIENT_SECRET']
-    api_url += "?client_id=#{ENV['GITHUB_CLIENT_ID']}&client_secret=#{ENV['GITHUB_CLIENT_SECRET']}"
+  if ENV['GITHUB_TOKEN']
+    api_url += "?access_token=#{ENV['GITHUB_TOKEN']}"
   end
 
   begin


### PR DESCRIPTION
Hi,
for a script like this that is not a webapp I think it's better and simpler for all users to use [github access token](https://github.com/settings/tokens).